### PR TITLE
ci: change upload-artifact & download-artifact to Cysharp/Actions

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -60,3 +60,4 @@ jobs:
         with:
           name: StructureOfArraysGenerator.${{ matrix.unity }}.unitypackage
           path: ./src/StructureOfArraysGenerator.Unity/*.unitypackage
+          retention-days: 1

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -56,7 +56,7 @@ jobs:
           directory: src/StructureOfArraysGenerator.Unity
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: StructureOfArraysGenerator.${{ matrix.unity }}.unitypackage
           path: ./src/StructureOfArraysGenerator.Unity/*.unitypackage

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,7 +36,7 @@ jobs:
       - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
       - run: dotnet test -c Release --no-build
       - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
-      - uses: actions/upload-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
           path: ./publish
@@ -82,7 +82,7 @@ jobs:
         with:
           directory: src/StructureOfArraysGenerator.Unity
       # Store artifacts.
-      - uses: actions/upload-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: StructureOfArraysGenerator.${{ inputs.tag }}.unitypackage
           path: ./src/StructureOfArraysGenerator.Unity/StructureOfArraysGenerator.${{ inputs.tag }}.unitypackage

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           name: nuget
           path: ./publish
+          retention-days: 1
 
   build-unity:
     needs: [update-packagejson]
@@ -87,6 +88,7 @@ jobs:
           name: StructureOfArraysGenerator.${{ inputs.tag }}.unitypackage
           path: ./src/StructureOfArraysGenerator.Unity/StructureOfArraysGenerator.${{ inputs.tag }}.unitypackage
           if-no-files-found: error
+          retention-days: 1
 
   # release
   create-release:


### PR DESCRIPTION
## tl;dr;

To handle actions/upload-artifact & download-artifact version consistency, manage actions version via Central Maanged Cysharp/Actions.
